### PR TITLE
fix: issue when there's parameters in url

### DIFF
--- a/feedly.php
+++ b/feedly.php
@@ -112,7 +112,7 @@ class Feedly {
         $r = null;
 
         if(is_array($get_params))
-            $url = $url . http_build_query($get_params);
+            $url = $url . '?' . http_build_query($get_params);
 
         if (($r = @curl_init($url)) == false) {
             throw new Exception("Cannot initialize cUrl session.


### PR DESCRIPTION
Hi,

When you're starting to use methods from the class Feedly with parameters (GET), the url used by your method InitCurl() isn't right.
Indeed, a '?' is missing when you're doing your concatenation.

For example: for the method getStreamContent('user/5e60ca13-09c3-4a4f-a735-b22204085d3c/category/news', ...)
the url used by InitCurl() is 
https://sandbox.feedly.com/v3/streams/contentsstreamId=user%2F5e60ca13-09c3-4a4f-a735-b22204085d3c%2Fcategory%2Fnews
