### PR TITLE
Add expiry to session, and name variables to be less generic.

### DIFF
--- a/example/authentication.php
+++ b/example/authentication.php
@@ -38,7 +38,7 @@ if (isset($_GET['code'])) {
     echo $token;
 }
 
-if (!isset($_SESSION['access_token'])) {
+if (!isset($_SESSION['feedly_access_token'])) {
     /**
      * After redirection replace "localhost" with your domain
      * keeping the Auth Code GET param

--- a/example/profile.php
+++ b/example/profile.php
@@ -17,7 +17,7 @@ $sandboxMode ?
         dirname($_SERVER['PHP_SELF']);
 
 
-$model = $feedly->getEndpoint('Profile', $_SESSION['access_token']);
+$model = $feedly->getEndpoint('Profile', $_SESSION['feedly_access_token']);
 
 $response = $model->fetch();
 

--- a/src/feedly/feedly.php
+++ b/src/feedly/feedly.php
@@ -140,6 +140,7 @@ class Feedly
         if ($this->_storeAccessTokenToSession) {
             if (isset($response[ 'access_token' ])) {
                 $_SESSION[ 'feedly_access_token' ] = $response[ 'access_token' ];
+                $_SESSION[ 'feedly_access_expires'] = time() + $response[ 'expires_in' ];
                 session_write_close();
             }
         }
@@ -150,8 +151,12 @@ class Feedly
      */
     private function getAccessTokenFromSession()
     {
-        if (isset($_SESSION[ 'feedly_access_token' ])) {
-            return $_SESSION[ 'feedly_access_token' ];
+        if (isset($_SESSION[ 'feedly_access_token' ]) && isset($_SESSION[ 'feedly_access_expires' ])) {
+            if (time() < $_SESSION[ 'feedly_access_expires' ]) {
+                return $_SESSION[ 'feedly_access_token' ];
+            } else {
+                throw new \Exception("Access token expired", 2);        
+            }
         } else {
             throw new \Exception("No access token", 1);
         }

--- a/src/feedly/feedly.php
+++ b/src/feedly/feedly.php
@@ -139,7 +139,7 @@ class Feedly
     {
         if ($this->_storeAccessTokenToSession) {
             if (isset($response[ 'access_token' ])) {
-                $_SESSION[ 'access_token' ] = $response[ 'access_token' ];
+                $_SESSION[ 'feedly_access_token' ] = $response[ 'access_token' ];
                 session_write_close();
             }
         }
@@ -150,8 +150,8 @@ class Feedly
      */
     private function getAccessTokenFromSession()
     {
-        if (isset($_SESSION[ 'access_token' ])) {
-            return $_SESSION[ 'access_token' ];
+        if (isset($_SESSION[ 'feedly_access_token' ])) {
+            return $_SESSION[ 'feedly_access_token' ];
         } else {
             throw new \Exception("No access token", 1);
         }


### PR DESCRIPTION
I found 'access_token' to be a little too generic as a session, so I adjusted it to feedly_access_token.

It might even be better to take it a step further and go with something like `$_SESSION['feedly_api']['access_token']`.

I also added the expiration to the session, since knowing when the token will expire is pretty important to avoid getting error responses from the API.