### PR TITLE
Get accessToken should return more than just the access token

### DIFF
--- a/example/authentication.php
+++ b/example/authentication.php
@@ -21,9 +21,9 @@ $loginUrl = $feedly->getLoginUrl("sandbox", "http://localhost");
 if (isset($_GET['code'])) {
 
     /**
-     * Response will contain the Access Token
+     * Response will contain the Access Token and Refresh Token
      */
-    $token = $feedly->getAccessToken(
+    $tokens = $feedly->getToken(
         "sandbox",
         "A0SXFX54S3K0OC9GNCXG",
         $_GET['code'],
@@ -35,7 +35,7 @@ if (isset($_GET['code'])) {
      * @see https://groups.google.com/forum/#!topic/feedly-cloud/a_cGSAzv8bY
      */
 
-    echo $token;
+    echo $tokens;
 }
 
 if (!isset($_SESSION['feedly_access_token'])) {

--- a/example/authentication.php
+++ b/example/authentication.php
@@ -38,7 +38,7 @@ if (isset($_GET['code'])) {
     echo $token;
 }
 
-if (!isset($_SESSION['access_token'])) {
+if (!isset($_SESSION['feedly_access_token'])) {
     /**
      * After redirection replace "localhost" with your domain
      * keeping the Auth Code GET param

--- a/example/profile.php
+++ b/example/profile.php
@@ -17,7 +17,7 @@ $sandboxMode ?
         dirname($_SERVER['PHP_SELF']);
 
 
-$model = $feedly->getEndpoint('Profile', $_SESSION['access_token']);
+$model = $feedly->getEndpoint('Profile', $_SESSION['feedly_access_token']);
 
 $response = $model->fetch();
 

--- a/src/feedly/feedly.php
+++ b/src/feedly/feedly.php
@@ -140,6 +140,7 @@ class Feedly
         if ($this->_storeAccessTokenToSession) {
             if (isset($response[ 'access_token' ])) {
                 $_SESSION[ 'feedly_access_token' ] = $response[ 'access_token' ];
+                $_SESSION[ 'feedly_access_expires'] = time() + $response[ 'expires_in' ];
                 session_write_close();
             }
         }
@@ -150,8 +151,12 @@ class Feedly
      */
     private function getAccessTokenFromSession()
     {
-        if (isset($_SESSION[ 'feedly_access_token' ])) {
-            return $_SESSION[ 'feedly_access_token' ];
+        if (isset($_SESSION[ 'feedly_access_token' ]) && isset($_SESSION[ 'feedly_access_expires' ])) {
+            if (time() < $_SESSION[ 'feedly_access_expires' ]) {
+                return $_SESSION[ 'feedly_access_token' ];
+            } else {
+                throw new \Exception("Access token expired", 2);        
+            }
         } else {
             throw new \Exception("No access token", 1);
         }

--- a/src/feedly/feedly.php
+++ b/src/feedly/feedly.php
@@ -137,8 +137,12 @@ class Feedly
 
         $this->storeAccessTokenToSession($response);
 
-        if (isset($response[ 'access_token' ]))
-            return $response[ 'access_token' ];
+        if (isset($response[ 'access_token' ])) {
+            return array(
+                'access_token' => $response[ 'access_token' ],
+                'expires' => $response[ 'expires_in' ],  
+            );
+        }
     }
 
     private function storeAccessTokenToSession($response)

--- a/src/feedly/feedly.php
+++ b/src/feedly/feedly.php
@@ -77,14 +77,14 @@ class Feedly
     }
 
     /**
-     * Exchange a `code` got from `getLoginUrl` for an `Access Token`
+     * Exchange a `code` from `getLoginUrl` for `Access` and `Refresh` Tokens
      *
      * @param string $client_id     Client's ID provided by Feedly's Administrators
      * @param string $client_secret Client's Secret provided by Feedly's Administrators
      * @param string $auth_code     Code obtained from `getLoginUrl`
      * @param string $redirect_url  Endpoint to reroute with the results
      */
-    public function getAccessToken($client_id, $client_secret, $auth_code,
+    public function getTokens($client_id, $client_secret, $auth_code,
                                    $redirect_url)
     {
 
@@ -108,8 +108,14 @@ class Feedly
 
         $this->storeAccessTokenToSession($response);
 
-        if (isset($response[ 'access_token' ]))
-            return $response[ 'access_token' ];
+        if (isset($response[ 'access_token' ]) &&
+            isset($response[ 'refresh_token' ])) {
+            return array(
+                'access_token' => $response[ 'access_token' ],
+                'refresh_token' => $response[ 'refresh_token' ],
+                'expires' => $response[ 'expires_in' ],
+            );
+        }
     }
 
     public function getRefreshAccessToken($client_id, $client_secret, $refresh_token)

--- a/src/feedly/feedly.php
+++ b/src/feedly/feedly.php
@@ -139,7 +139,7 @@ class Feedly
     {
         if ($this->_storeAccessTokenToSession) {
             if (isset($response[ 'access_token' ])) {
-                $_SESSION[ 'access_token' ] = $response[ 'access_token' ];
+                $_SESSION[ 'feedly_access_token' ] = $response[ 'access_token' ];
                 session_write_close();
             }
         }
@@ -150,8 +150,8 @@ class Feedly
      */
     private function getAccessTokenFromSession()
     {
-        if (isset($_SESSION[ 'access_token' ])) {
-            return $_SESSION[ 'access_token' ];
+        if (isset($_SESSION[ 'feedly_access_token' ])) {
+            return $_SESSION[ 'feedly_access_token' ];
         } else {
             throw new \Exception("No access token", 1);
         }

--- a/tests/FeedlyAPIWrapperTest.php
+++ b/tests/FeedlyAPIWrapperTest.php
@@ -43,7 +43,7 @@ class FeedlyAPIWrapperTest extends PHPUnit_Framework_TestCase
     {
 
         $response = array(
-            'access_token' => 'dsa5da76d76sa5d67sad567a'
+            'access_token' => 'dsa5da76d76sa5d67sad567a',
             'expires_in' => '1234',
         );
 

--- a/tests/FeedlyAPIWrapperTest.php
+++ b/tests/FeedlyAPIWrapperTest.php
@@ -44,6 +44,7 @@ class FeedlyAPIWrapperTest extends PHPUnit_Framework_TestCase
 
         $response = array(
             'access_token' => 'dsa5da76d76sa5d67sad567a'
+            'expires_in' => '1234',
         );
 
         $feedly = $this->getMock('Feedly', array('getRefreshAccessToken'));

--- a/tests/FeedlyAPIWrapperTest.php
+++ b/tests/FeedlyAPIWrapperTest.php
@@ -21,20 +21,22 @@ class FeedlyAPIWrapperTest extends PHPUnit_Framework_TestCase
         $this->assertNotEmpty($feedly->getLoginUrl("sandbox", "http://localhost"));
     }
 
-    public function testGetAccessToken()
+    public function testGetTokens()
     {
 
         $response = array(
-            'access_token' => 'dsa5da76d76sa5d67sad567a'
+            'access_token' => 'dsa5da76d76sa5d67sad567a',
+            'expires_in' => '1234',
+            'refresh_token' => 'absa5da76d76sa5d87sad597a'
         );
 
-        $feedly = $this->getMock('Feedly', array('getAccessToken'));
+        $feedly = $this->getMock('Feedly', array('getToken'));
 
         $feedly->expects($this->any())
-               ->method('getAccessToken')
+               ->method('getToken')
                ->will($this->returnValue($response));
 
-        $this->assertEquals($response, $feedly->getAccessToken());
+        $this->assertEquals($response, $feedly->getToken());
     }
 
     public function testGetRefreshAccessToken()


### PR DESCRIPTION
As the wrapper currently is, I wasn't really sure what to do with respect to refresh tokens.  This API wrapper doesn't seem to return it in any function calls, so if my application needed to get a new access token I couldn't use a refresh token to get a new one.

So I switched `getAccessToken` to `getTokens`, which is largely the same but will return the access token, the expiration of the access token, and the refresh token we can use later.  Slightly same update to `getRefreshToken()`.